### PR TITLE
Feat [#3] 기본 클래스들 세팅

### DIFF
--- a/jaksim/src/main/java/org/sopt/jaksim/global/common/ApiResponseUtil.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/global/common/ApiResponseUtil.java
@@ -1,0 +1,22 @@
+package org.sopt.jaksim.global.common;
+
+import org.sopt.jaksim.global.message.ErrorMessage;
+import org.sopt.jaksim.global.message.SuccessMessage;
+import org.springframework.http.ResponseEntity;
+
+public interface ApiResponseUtil {
+    static ResponseEntity<BaseResponse<?>> success(SuccessMessage successMessage) {
+        return ResponseEntity.status(successMessage.getHttpStatus())
+                .body(BaseResponse.of(successMessage));
+    }
+
+    static <T> ResponseEntity<BaseResponse<?>> success(SuccessMessage successMessage, T data) {
+        return ResponseEntity.status(successMessage.getHttpStatus())
+                .body(BaseResponse.of(successMessage, data));
+    }
+
+    static ResponseEntity<BaseResponse<?>> failure(ErrorMessage errorMessage) {
+        return ResponseEntity.status(errorMessage.getHttpStatus())
+                .body(BaseResponse.of(errorMessage));
+    }
+}

--- a/jaksim/src/main/java/org/sopt/jaksim/global/common/BaseResponse.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/global/common/BaseResponse.java
@@ -1,0 +1,45 @@
+package org.sopt.jaksim.global.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.sopt.jaksim.global.message.ErrorMessage;
+import org.sopt.jaksim.global.message.SuccessMessage;
+
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class BaseResponse<T> {
+    private final int status;
+    private final String code;
+    private final String message;
+    @JsonInclude(value = JsonInclude.Include.NON_NULL)
+    private final T data;
+
+    public static BaseResponse<?> of(SuccessMessage successMessage) {
+        return builder()
+                .status(successMessage.getHttpStatus().value())
+                .code(successMessage.getCode())
+                .message(successMessage.getMessage())
+                .build();
+    }
+
+    public static <T> BaseResponse<?> of(SuccessMessage successMessage, T data) {
+        return builder()
+                .status(successMessage.getHttpStatus().value())
+                .code(successMessage.getCode())
+                .message(successMessage.getMessage())
+                .data(data)
+                .build();
+    }
+
+    public static BaseResponse<?> of(ErrorMessage errorMessage) {
+        return builder()
+                .status(errorMessage.getHttpStatus().value())
+                .code(errorMessage.getCode())
+                .message(errorMessage.getMessage())
+                .build();
+    }
+}

--- a/jaksim/src/main/java/org/sopt/jaksim/global/common/BaseTimeEntity.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/global/common/BaseTimeEntity.java
@@ -1,0 +1,22 @@
+package org.sopt.jaksim.global.common;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/jaksim/src/main/java/org/sopt/jaksim/global/common/GlobalExceptionHandler.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/global/common/GlobalExceptionHandler.java
@@ -28,13 +28,13 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(ForbiddenException.class)
     protected ResponseEntity<BaseResponse<?>> handleForbiddenException(ForbiddenException e) {
-        log.error(">>> handle: NotFoundException ", e);
+        log.error(">>> handle: ForbiddenException ", e);
         return ApiResponseUtil.failure(ErrorMessage.FORBIDDEN);
     }
 
     @ExceptionHandler(UnauthorizedException.class)
     protected ResponseEntity<BaseResponse<?>> handlerUnauthorizedException(UnauthorizedException e) {
-        log.error(">>> handle: NotFoundException ", e);
+        log.error(">>> handle: UnauthorizedException ", e);
         return ApiResponseUtil.failure(ErrorMessage.UNAUTHORIZED);
     }
 }

--- a/jaksim/src/main/java/org/sopt/jaksim/global/common/GlobalExceptionHandler.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/global/common/GlobalExceptionHandler.java
@@ -1,0 +1,38 @@
+package org.sopt.jaksim.global.common;
+
+import org.sopt.jaksim.global.common.dto.ErrorResponse;
+import org.sopt.jaksim.global.exception.ForbiddenException;
+import org.sopt.jaksim.global.exception.NotFoundException;
+import org.sopt.jaksim.global.exception.UnauthorizedException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Objects;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse.of(HttpStatus.BAD_REQUEST.value(), Objects.requireNonNull(e.getBindingResult().getFieldError()).getDefaultMessage()));
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    protected ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse.of(e.errorMessage));
+    }
+
+    @ExceptionHandler(ForbiddenException.class)
+    protected ResponseEntity<ErrorResponse> handleForbiddenException(ForbiddenException e) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ErrorResponse.of(e.errorMessage));
+    }
+
+    @ExceptionHandler(UnauthorizedException.class)
+    protected ResponseEntity<ErrorResponse> handlerUnauthorizedException(UnauthorizedException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ErrorResponse.of(e.getErrorMessage().getStatus(), e.getErrorMessage().getMessage()));
+    }
+}

--- a/jaksim/src/main/java/org/sopt/jaksim/global/common/GlobalExceptionHandler.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/global/common/GlobalExceptionHandler.java
@@ -1,38 +1,40 @@
 package org.sopt.jaksim.global.common;
 
-import org.sopt.jaksim.global.common.dto.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.sopt.jaksim.global.exception.ForbiddenException;
 import org.sopt.jaksim.global.exception.NotFoundException;
 import org.sopt.jaksim.global.exception.UnauthorizedException;
-import org.springframework.http.HttpStatus;
+import org.sopt.jaksim.global.message.ErrorMessage;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import java.util.Objects;
-
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse.of(HttpStatus.BAD_REQUEST.value(), Objects.requireNonNull(e.getBindingResult().getFieldError()).getDefaultMessage()));
+    protected ResponseEntity<BaseResponse<?>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.error(">>> handle: MethodArgumentNotValidException ", e);
+        return ApiResponseUtil.failure(ErrorMessage.BAD_REQUEST);
     }
 
     @ExceptionHandler(NotFoundException.class)
-    protected ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException e) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse.of(e.errorMessage));
+    protected ResponseEntity<BaseResponse<?>> handleNotFoundException(NotFoundException e) {
+        log.error(">>> handle: NotFoundException ", e);
+        return ApiResponseUtil.failure(ErrorMessage.NOT_FOUND);
     }
 
     @ExceptionHandler(ForbiddenException.class)
-    protected ResponseEntity<ErrorResponse> handleForbiddenException(ForbiddenException e) {
-        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ErrorResponse.of(e.errorMessage));
+    protected ResponseEntity<BaseResponse<?>> handleForbiddenException(ForbiddenException e) {
+        log.error(">>> handle: NotFoundException ", e);
+        return ApiResponseUtil.failure(ErrorMessage.FORBIDDEN);
     }
 
     @ExceptionHandler(UnauthorizedException.class)
-    protected ResponseEntity<ErrorResponse> handlerUnauthorizedException(UnauthorizedException e) {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(ErrorResponse.of(e.getErrorMessage().getStatus(), e.getErrorMessage().getMessage()));
+    protected ResponseEntity<BaseResponse<?>> handlerUnauthorizedException(UnauthorizedException e) {
+        log.error(">>> handle: NotFoundException ", e);
+        return ApiResponseUtil.failure(ErrorMessage.UNAUTHORIZED);
     }
 }

--- a/jaksim/src/main/java/org/sopt/jaksim/global/common/HealthCheckController.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/global/common/HealthCheckController.java
@@ -1,16 +1,14 @@
-package org.sopt.jaksim;
+package org.sopt.jaksim.global.common;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.env.Environment;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
-
 import java.util.Arrays;
 
 @RestController
 @RequiredArgsConstructor
-public class ProfileController {
-
+public class HealthCheckController {
     private final Environment env;
     private static final String NULL = "";
 
@@ -19,6 +17,6 @@ public class ProfileController {
         return Arrays.stream(env.getActiveProfiles())
                 .findFirst()
                 .orElse(NULL);
-        
     }
+
 }

--- a/jaksim/src/main/java/org/sopt/jaksim/global/config/JpaAuditingConfig.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/global/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package org.sopt.jaksim.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/jaksim/src/main/java/org/sopt/jaksim/global/exception/BusinessException.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/global/exception/BusinessException.java
@@ -1,0 +1,14 @@
+package org.sopt.jaksim.global.exception;
+
+import lombok.Getter;
+import org.sopt.jaksim.global.message.ErrorMessage;
+
+@Getter
+public class BusinessException extends RuntimeException {
+    public ErrorMessage errorMessage;
+
+    public BusinessException(ErrorMessage errorMessage) {
+        super(errorMessage.getMessage());
+        this.errorMessage = errorMessage;
+    }
+}

--- a/jaksim/src/main/java/org/sopt/jaksim/global/exception/ForbiddenException.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/global/exception/ForbiddenException.java
@@ -1,0 +1,9 @@
+package org.sopt.jaksim.global.exception;
+
+import org.sopt.jaksim.global.message.ErrorMessage;
+
+public class ForbiddenException extends BusinessException {
+    public ForbiddenException(ErrorMessage errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/jaksim/src/main/java/org/sopt/jaksim/global/exception/InvalidValueException.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/global/exception/InvalidValueException.java
@@ -1,0 +1,13 @@
+package org.sopt.jaksim.global.exception;
+
+import org.sopt.jaksim.global.message.ErrorMessage;
+
+public class InvalidValueException extends BusinessException {
+    public InvalidValueException() {
+        super(ErrorMessage.BAD_REQUEST);
+    }
+
+    public InvalidValueException(ErrorMessage errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/jaksim/src/main/java/org/sopt/jaksim/global/exception/NotFoundException.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/global/exception/NotFoundException.java
@@ -1,0 +1,9 @@
+package org.sopt.jaksim.global.exception;
+
+import org.sopt.jaksim.global.message.ErrorMessage;
+
+public class NotFoundException extends BusinessException {
+    public NotFoundException(ErrorMessage errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/jaksim/src/main/java/org/sopt/jaksim/global/exception/UnauthorizedException.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/global/exception/UnauthorizedException.java
@@ -1,0 +1,9 @@
+package org.sopt.jaksim.global.exception;
+
+import org.sopt.jaksim.global.message.ErrorMessage;
+
+public class UnauthorizedException extends BusinessException {
+    public UnauthorizedException(ErrorMessage errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/jaksim/src/main/java/org/sopt/jaksim/global/message/ErrorMessage.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/global/message/ErrorMessage.java
@@ -17,17 +17,19 @@ public enum ErrorMessage {
     /**
      * 401 Unauthorized
      */
-    JWT_UNAUTHORIZED_EXCEPTION(HttpStatus.UNAUTHORIZED, "e4010", "사용자의 로그인 검증을 실패했습니다."),
-    PASSWORD_NOT_MATCHED_EXCEPTION(HttpStatus.UNAUTHORIZED, "e4010", "해당 유저의 비밀번호가 일치하지 않습니다."),
-    ;
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "e4010", "리소스 접근 권한이 없습니다."),
+    JWT_UNAUTHORIZED_EXCEPTION(HttpStatus.UNAUTHORIZED, "e4011", "사용자의 로그인 검증을 실패했습니다."),
+    PASSWORD_NOT_MATCHED_EXCEPTION(HttpStatus.UNAUTHORIZED, "e4012", "해당 유저의 비밀번호가 일치하지 않습니다."),
 
     /**
      * 403 Forbidden
      */
+    FORBIDDEN(HttpStatus.FORBIDDEN, "e4030", "리소스 접근 권한이 없습니다."),
 
     /**
      * 404 Not Found
      */
+    NOT_FOUND(HttpStatus.NOT_FOUND, "e4040", "대상을 찾을 수 없습니다."),
 
     /**
      * 405 Method Not Allowed
@@ -40,6 +42,7 @@ public enum ErrorMessage {
     /**
      * 500 Internal Server Error
      */
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/jaksim/src/main/java/org/sopt/jaksim/global/message/ErrorMessage.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/global/message/ErrorMessage.java
@@ -1,0 +1,47 @@
+package org.sopt.jaksim.global.message;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public enum ErrorMessage {
+    /**
+     * 400 Bad Request
+     */
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "e4000", "잘못된 요청입니다."),
+    INVALID_PLATFORM_TYPE(HttpStatus.BAD_REQUEST, "e4001", "유효하지 않은 플랫폼 타입입니다."),
+
+    /**
+     * 401 Unauthorized
+     */
+    JWT_UNAUTHORIZED_EXCEPTION(HttpStatus.UNAUTHORIZED, "e4010", "사용자의 로그인 검증을 실패했습니다."),
+    PASSWORD_NOT_MATCHED_EXCEPTION(HttpStatus.UNAUTHORIZED, "e4010", "해당 유저의 비밀번호가 일치하지 않습니다."),
+    ;
+
+    /**
+     * 403 Forbidden
+     */
+
+    /**
+     * 404 Not Found
+     */
+
+    /**
+     * 405 Method Not Allowed
+     */
+
+    /**
+     * 409 Conflict
+     */
+
+    /**
+     * 500 Internal Server Error
+     */
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+   }

--- a/jaksim/src/main/java/org/sopt/jaksim/global/message/SuccessMessage.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/global/message/SuccessMessage.java
@@ -1,0 +1,25 @@
+package org.sopt.jaksim.global.message;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public enum SuccessMessage {
+    /**
+     * 200 Ok
+     */
+    USER_SIGN_UP_SUCCESS(HttpStatus.OK, "s2000", "회원가입이 완료되었습니다."),
+    USER_SIGN_IN_SUCCESS(HttpStatus.OK, "s2000", "로그인이 완료되었습니다."),
+    ;
+
+    /**
+     * 201 Created
+     */
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/jaksim/src/main/java/org/sopt/jaksim/user/api/UserApiController.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/user/api/UserApiController.java
@@ -1,0 +1,12 @@
+package org.sopt.jaksim.user.api;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+@Controller
+public class UserApiController {
+
+}

--- a/jaksim/src/main/java/org/sopt/jaksim/user/domain/Platform.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/user/domain/Platform.java
@@ -1,0 +1,22 @@
+package org.sopt.jaksim.user.domain;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.sopt.jaksim.global.exception.InvalidValueException;
+import org.sopt.jaksim.global.message.ErrorMessage;
+
+import java.util.Arrays;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum Platform {
+    GOOGLE("Google");
+
+    private final String stringPlatform;
+
+    public static Platform getEnumPlatformFromStringPlatform(String stringPlatform) {
+        return Arrays.stream(values())
+                .filter(platform -> platform.stringPlatform.equals(stringPlatform))
+                .findFirst()
+                .orElseThrow(() -> new InvalidValueException(ErrorMessage.INVALID_PLATFORM_TYPE));
+    }
+}

--- a/jaksim/src/main/java/org/sopt/jaksim/user/domain/User.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/user/domain/User.java
@@ -1,0 +1,26 @@
+package org.sopt.jaksim.user.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.sopt.jaksim.global.common.BaseTimeEntity;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+@Table(name = "users")
+@Entity
+public class User extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+    @Column(nullable = false)
+    private String email;
+    @Column(nullable = false)
+    private String name;
+    @Enumerated(EnumType.STRING)
+    private Platform platform;
+    private String refreshToken;
+
+}

--- a/jaksim/src/main/java/org/sopt/jaksim/user/dto/request/UserSignInRequest.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/user/dto/request/UserSignInRequest.java
@@ -1,0 +1,4 @@
+package org.sopt.jaksim.user.dto.request;
+
+public record UserSignInRequest() {
+}

--- a/jaksim/src/main/java/org/sopt/jaksim/user/dto/response/UserSignInResponse.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/user/dto/response/UserSignInResponse.java
@@ -1,0 +1,4 @@
+package org.sopt.jaksim.user.dto.response;
+
+public record UserSignInResponse() {
+}

--- a/jaksim/src/main/java/org/sopt/jaksim/user/facade/UserFacade.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/user/facade/UserFacade.java
@@ -1,0 +1,4 @@
+package org.sopt.jaksim.user.facade;
+
+public class UserFacade {
+}

--- a/jaksim/src/main/java/org/sopt/jaksim/user/repository/UserRepository.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.jaksim.user.repository;
+
+import org.sopt.jaksim.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/jaksim/src/main/java/org/sopt/jaksim/user/service/UserService.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/user/service/UserService.java
@@ -1,0 +1,4 @@
+package org.sopt.jaksim.user.service;
+
+public class UserService {
+}


### PR DESCRIPTION
- closes #3 

_기본적으로 필요한 클래스들 세팅했습니다. 패키지 별로 클래스 설명드릴게요 :)_

# global 
## common : 공통적으로 사용하는 클래스 패키지
### BaseResponse
- 기존 세미나 코드에서의 SuccessResponse, ErrorResponse를 포함합니다.

### ApiResponseUtil
- BaseResponse를 타입으로 받아 ResponseEntity를 생성해 실제로 반환되는 인터페이스입니다.

### BaseTimeEntity
- createdAt, updatedAt을 각 엔티티에서 필드로 생성하지 않고 상속받아 사용할 수 있도록 하는 상속 클래스입니다.

### GlobalExceptionHandler
- 스프링 애플리케이션 내에서 커스텀 Exception을 발생시키면 잡는 핸들러 클래스입니다.

### HealthCheckController
- CI Health Check 용 컨트롤러 클래스입니다.

## exception
커스텀 Exception 들을 정의한 패키지

## message
Success, Error Message를 정의한 패키지

</br>

# user
## controller - UserApiController
User 관련 api를 받는 컨트롤러 클래스

## domain - User, Platform
User 도메인 클래스
소셜 로그인 시 어떤 플랫폼인지 알 수 있게 하는 Enum 클래스

## dto - UserSignInRequest, UserSignInResponse
사용자가 회원가입 시, 요청/응답하는 dto
JWT 구현해주신 후, 여기에 어떤 데이터들이 들어갈 지 생각해보시면 좋을 것 같아요 ! :)

## facade - UserFacade
Facade 메소드 패턴을 도입해보려고 합니다!
컨트롤러 레이어와 서비스 레이어 사이의 연결점이라고 생각해주시면 될 것 같아요 :)

예를 들어, 원래는 UserApiController가 UserService 의존성을 주입받아 바로 호출했었는데요!
이렇게 되면 컨트롤러와 서비스 레이어의 의존성이 높아지기 때문에, 
이를 해결하기 위해 Facade 레이어를 추가하여 Service 레이어를 호출하는 레이어는 유일하게 Facade 레이어가 되도록 합니다!
(잘 이해가 안되신다면, 다시 말씀해주세요 -!)

## service - UserService
User 관련 비즈니스 로직을 수행하는 서비스 클래스입니다.

## repository - UserRepository
DB의 User 테이블에서 Jpa로 엔티티를 가져오는 레포지토리 클래스입니다.

기본적인 클래스 세팅은 일단 생각나는대로 해봤는데요 !
JWT 관련 클래스는 루트에서 auth 패키지를 만들어서 진행해주시면 됩니다. :) 화이팅 !!!
(JwtAuthenticationFilter, UserAuthentication, ... 등등)