### PR TITLE
Chore [#6] Dockerfile 수정

### DIFF
--- a/jaksim/Dockerfile
+++ b/jaksim/Dockerfile
@@ -9,4 +9,4 @@ ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
 
 # 운영 및 개발에서 사용되는 환경 설정을 분리
-ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=dev", "app.jar"]
+ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=prod", "app.jar"]


### PR DESCRIPTION
Dockerfile 수정했습니다. 

```
# open jdk 17
FROM eclipse-temurin:17

# build가 되는 시점에 JAR_FILE이라는 변수 명에 build/libs/*.jar 선언
# build/libs - gradle로 빌드했을 때 jar 파일이 생성되는 경로
ARG JAR_FILE=build/libs/*.jar

# JAR_FILE을 app.jar로 복사
COPY ${JAR_FILE} app.jar

# 운영 및 개발에서 사용되는 환경 설정을 분리
ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=prod", "app.jar"]
```

Entry Point를 prod로 변경 -!