### PR TITLE
Fix [#13] Reissue API 수정

### DIFF
--- a/jaksim/src/main/java/org/sopt/jaksim/global/message/SuccessMessage.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/global/message/SuccessMessage.java
@@ -12,7 +12,8 @@ public enum SuccessMessage {
      * 200 Ok
      */
     USER_SIGN_UP_SUCCESS(HttpStatus.OK, "s2000", "회원가입이 완료되었습니다."),
-    USER_SIGN_IN_SUCCESS(HttpStatus.OK, "s2000", "로그인이 완료되었습니다."),
+    USER_SIGN_IN_SUCCESS(HttpStatus.OK, "s2001", "로그인이 완료되었습니다."),
+    USER_TOKEN_REISSUE_SUCCESS(HttpStatus.OK, "s2002", "토큰 재발급이 완료되었습니다."),
     ;
 
     /**

--- a/jaksim/src/main/java/org/sopt/jaksim/user/api/UserApiController.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/user/api/UserApiController.java
@@ -2,6 +2,7 @@ package org.sopt.jaksim.user.api;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.jaksim.auth.PrincipalHandler;
+import org.sopt.jaksim.global.common.ApiResponseUtil;
 import org.sopt.jaksim.global.common.BaseResponse;
 import org.sopt.jaksim.global.message.SuccessMessage;
 import org.sopt.jaksim.user.dto.request.UserReissueRequest;
@@ -33,12 +34,10 @@ public class UserApiController {
 //
 
     @PostMapping("/reissue")
-    public ResponseEntity<UserSignInResponse> reissue(@RequestHeader(AUTHORIZATION) final String refreshToken,
+    public ResponseEntity<BaseResponse<?>> reissue(@RequestHeader(AUTHORIZATION) final String refreshToken,
                                                       @RequestBody final UserReissueRequest userReissueRequest) {
         UserSignInResponse response = userFacade.reissue(refreshToken, userReissueRequest);
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .header("Location", response.userId())
-                .body(response);
+        return ApiResponseUtil.success(SuccessMessage.USER_TOKEN_REISSUE_SUCCESS, response);
     }
 
 }

--- a/jaksim/src/main/java/org/sopt/jaksim/user/api/UserApiController.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/user/api/UserApiController.java
@@ -2,18 +2,19 @@ package org.sopt.jaksim.user.api;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.jaksim.auth.PrincipalHandler;
+import org.sopt.jaksim.global.common.BaseResponse;
 import org.sopt.jaksim.global.message.SuccessMessage;
+import org.sopt.jaksim.user.dto.request.UserReissueRequest;
 import org.sopt.jaksim.user.dto.request.UserSignInRequest;
 import org.sopt.jaksim.user.dto.response.UserSignInResponse;
+import org.sopt.jaksim.user.facade.UserFacade;
 import org.sopt.jaksim.user.service.UserService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import static org.sopt.jaksim.global.common.Constants.AUTHORIZATION;
 import static org.sopt.jaksim.global.message.SuccessMessage.USER_SIGN_IN_SUCCESS;
 
 @RestController
@@ -21,29 +22,29 @@ import static org.sopt.jaksim.global.message.SuccessMessage.USER_SIGN_IN_SUCCESS
 @RequestMapping("/api/v1")
 public class UserApiController {
 
-    private final UserService userService;
-    private final PrincipalHandler principalHandler;
+    private final UserFacade userFacade;
 
-    @PostMapping("/user/login")
-    public ResponseEntity<SuccessStatusResponse<UserSignInResponse>> login(@RequestBody UserSignInRequest userSignInRequest) {
-        UserSignInResponse response = userService.login(userSignInRequest);
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(SuccessStatusResponse.of(SuccessMessage.USER_SIGN_IN_SUCCESS, response));
-    }
-//ApiResponseUtil<BaseResponse<UserSignInResponse>>>
-    // public ApiResponseUtil<BaseResponse ....
-    @PostMapping("/refresh")
-    public ResponseEntity<UserSignInResponse> refreshToken() {
-        Long userId = principalHandler.getUserIdFromPrincipal();
-        UserSignInResponse response = userService.refreshToken(userId);
+//    @PostMapping("/user/login")
+//    public ResponseEntity<BaseResponse<UserSignInResponse>> login(@RequestBody UserSignInRequest userSignInRequest) {
+//        final UserSignInResponse response = userFacade.login(userSignInRequest);
+//        return ResponseEntity.status(HttpStatus.OK)
+//                .body(SuccessStatusResponse.of(SuccessMessage.USER_SIGN_IN_SUCCESS, response));
+//    }
+//
+
+    @PostMapping("/reissue")
+    public ResponseEntity<UserSignInResponse> reissue(@RequestHeader(AUTHORIZATION) final String refreshToken,
+                                                      @RequestBody final UserReissueRequest userReissueRequest) {
+        UserSignInResponse response = userFacade.reissue(refreshToken, userReissueRequest);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .header("Location", response.userId())
                 .body(response);
     }
-}
-
-
 
 }
+
+
+
+
 
 

--- a/jaksim/src/main/java/org/sopt/jaksim/user/domain/User.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/user/domain/User.java
@@ -8,6 +8,7 @@ import org.sopt.jaksim.global.common.BaseTimeEntity;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(access = AccessLevel.PRIVATE)
 @Getter
+@Setter
 @Table(name = "users")
 @Entity
 public class User extends BaseTimeEntity {

--- a/jaksim/src/main/java/org/sopt/jaksim/user/dto/request/UserReissueRequest.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/user/dto/request/UserReissueRequest.java
@@ -1,0 +1,6 @@
+package org.sopt.jaksim.user.dto.request;
+
+public record UserReissueRequest(
+        Long userId
+) {
+}

--- a/jaksim/src/main/java/org/sopt/jaksim/user/dto/request/UserSignInRequest.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/user/dto/request/UserSignInRequest.java
@@ -1,7 +1,6 @@
 package org.sopt.jaksim.user.dto.request;
 
 public record UserSignInRequest(
-    String userId,
-    String password
+    String platform
 ){
 }

--- a/jaksim/src/main/java/org/sopt/jaksim/user/facade/UserFacade.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/user/facade/UserFacade.java
@@ -1,4 +1,17 @@
 package org.sopt.jaksim.user.facade;
 
+import lombok.RequiredArgsConstructor;
+import org.sopt.jaksim.user.dto.request.UserReissueRequest;
+import org.sopt.jaksim.user.dto.response.UserSignInResponse;
+import org.sopt.jaksim.user.service.UserService;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
 public class UserFacade {
+    private final UserService userService;
+
+    public UserSignInResponse reissue(String refreshToken, UserReissueRequest userReissueRequest) {
+        return userService.reissue(refreshToken, userReissueRequest);
+    }
 }

--- a/jaksim/src/main/java/org/sopt/jaksim/user/repository/UserRepository.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/user/repository/UserRepository.java
@@ -1,7 +1,11 @@
 package org.sopt.jaksim.user.repository;
 
+import org.sopt.jaksim.user.domain.Platform;
 import org.sopt.jaksim.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findUserByPlatformAndEmail(Platform platform, String email);
 }

--- a/jaksim/src/main/resources/application.yml
+++ b/jaksim/src/main/resources/application.yml
@@ -1,6 +1,0 @@
-spring:
-  profiles:
-    active: dev
-
-jwt:
-  secret: nowsoptnowsoptnownownononwonwownwownownwowno


### PR DESCRIPTION
## 🍀 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
Reissue 관련 API 수정했습니다. SignIn API 는 소셜 로그인 구현 후 수정 예정이므로 주석 처리 했습니다 :)

### controller - UserApiController
https://github.com/jaksim-us/Jaksim-Server/blob/b967fa9a754d66bc4cb48b05622d4a59be51b5c4/jaksim/src/main/java/org/sopt/jaksim/user/api/UserApiController.java#L36-L41


- 메소드명은 간단한 명사형으로 수정했습니다 `reissue()`
- Facade 패턴을 적용해 Controller와 Service 사이의 의존도를 낮췄습니다. (Controller에서는 Facade만을 의존)
- UserSignInResponse를 재사용해 토큰을 재발급했습니다. (네이밍은 수정해야할 것 같습니다!)
- `@RequestHeader(AUTHORIZATION)` 으로 rtk를 받아 토큰을 재발급합니다.
- ApiResponse, BaseResponse를 사용해 반환 타입을 재정의했습니다.
- SuccessMessage에 토큰 재발급 성공 메시지를 추가했습니다.

### facade - UserFacade
https://github.com/jaksim-us/Jaksim-Server/blob/b967fa9a754d66bc4cb48b05622d4a59be51b5c4/jaksim/src/main/java/org/sopt/jaksim/user/facade/UserFacade.java#L11-L16
- userService 의존성을 주입받습니다.
- controller와 service 간의 결합도를 낮춰주는 레이어 클래스입니다.

### service - UserService
service 레이어의 경우, 소셜 로그인이 들어가도 로그인 과정이 비슷할 것 같아 수정을 완료했습니다. (추후 수정할 수 있음!)

https://github.com/jaksim-us/Jaksim-Server/blob/b967fa9a754d66bc4cb48b05622d4a59be51b5c4/jaksim/src/main/java/org/sopt/jaksim/user/service/UserService.java#L28-L45

https://github.com/jaksim-us/Jaksim-Server/blob/b967fa9a754d66bc4cb48b05622d4a59be51b5c4/jaksim/src/main/java/org/sopt/jaksim/user/service/UserService.java#L28-L45

- 로그인 Service 메소드입니다.
- UserSignInRequest에서 platform(GOOGLE) 정보를 뽑아 Enum으로 추출하고, controller로부터 넘어온 atk를 가지고 유저의 이메일을 추출합니다. (getUserByPlatformAndEmail)
- atk, rtk를 발급합니다.
- redis에 rtk를 저장합니다. 이 때, 정적 팩토리 메소드 패턴을 사용합니다. (of)
- UserSignInResponse를 반환합니다. (정적 팩토리 메소드 패턴)

https://github.com/jaksim-us/Jaksim-Server/blob/b967fa9a754d66bc4cb48b05622d4a59be51b5c4/jaksim/src/main/java/org/sopt/jaksim/user/service/UserService.java#L47-L58

https://github.com/jaksim-us/Jaksim-Server/blob/b967fa9a754d66bc4cb48b05622d4a59be51b5c4/jaksim/src/main/java/org/sopt/jaksim/user/service/UserService.java#L60-L64

https://github.com/jaksim-us/Jaksim-Server/blob/b967fa9a754d66bc4cb48b05622d4a59be51b5c4/jaksim/src/main/java/org/sopt/jaksim/user/service/UserService.java#L60-L64

- 토큰 재발급 Service 메소드입니다.
- UserReissueRequest에서 userId를 추출합니다.
- controller로부터 넘어온 rtk가 유효한지 검증하는 로직을 추가합니다. (validateRefreshToken - jwt 검증 클래스를 따로 구현 예정)
- updateRefreshToken으로 users 테이블과 Redis를 업데이트합니다.
- UserSignInResponse를 재사용하여 반환합니다. (atk, rtk를 둘다 재발급해 반환)

<br>

## 🍀 어떤 것을 중점으로 리뷰 해주길 바라시나요?
- Facade 패턴
- 객체를 만들 때, 정적 팩토리 메소드 패턴
- ApiResonseUtil, BaseResponse를 사용한 controller 반환 스타일
- 각 메소드의 기능 

<br>

## 🍀 공통 작업 부분에 대한 수정 사항이 있다면 적어주세요
- yml을 생성해서 넣어두셨던데 전 기존에 yaml 확장자를 쓰고 있었고, 이는 .gitIgnore에 등록해 깃에 올라가면 안 됩니다. (비밀정보이므로) 
  추가하신 yml을 삭제한 뒤, 기존의 yaml에  jwt.secret을 임의의 값으로 수정하여 추가했습니다. 
  노션에 업데이트 해두겠습니다 :)

<br>

## 🍀 PR 유형
어떤 변경 사항인가요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 파일 혹은 패키지명 수정
- [ ] 파일 혹은 패키지 삭제

<br>

## 🍀 Checklist
- [x] 코드 컨벤션을 지켰나요?
- [x] git 컨벤션을 지켰나요?
- [x] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


### 🍀 Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #13
