### PR TITLE
[Feat] 소셜 로그인, 회원가입 구현

### DIFF
--- a/jaksim/build.gradle
+++ b/jaksim/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
+//    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     // lombok
@@ -39,6 +39,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     // oauth2 client
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'com.google.api-client:google-api-client:1.32.1'
+    implementation 'com.google.oauth-client:google-oauth-client:1.32.1'
+    implementation 'com.google.http-client:google-http-client-jackson2:1.40.0'
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
     // web socket
@@ -53,9 +56,12 @@ dependencies {
     implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
     implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 
-
     //Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.security:spring-security-messaging'
+
+    // JSONObject
+    implementation 'org.json:json:20210307'
 }
 
 tasks.named('test') {

--- a/jaksim/build.gradle
+++ b/jaksim/build.gradle
@@ -41,6 +41,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+    // web socket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/jaksim/src/main/java/org/sopt/jaksim/auth/filter/JwtAuthenticationFilter.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/auth/filter/JwtAuthenticationFilter.java
@@ -7,7 +7,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.sopt.jaksim.auth.UserAuthentication;
-import org.sopt.jaksim.global.common.jwt.JwtTokenProvider;
+import org.sopt.jaksim.auth.jwt.JwtTokenProvider;
 import org.sopt.jaksim.global.exception.UnauthorizedException;
 import org.sopt.jaksim.global.message.ErrorMessage;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -18,7 +18,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
-import static org.sopt.jaksim.global.common.jwt.JwtValidationType.VALID_JWT;
+import static org.sopt.jaksim.auth.jwt.JwtValidationType.VALID_JWT;
 
 @Component
 @RequiredArgsConstructor

--- a/jaksim/src/main/java/org/sopt/jaksim/auth/filter/JwtAuthenticationFilter.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/auth/filter/JwtAuthenticationFilter.java
@@ -19,6 +19,8 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 
 import static org.sopt.jaksim.auth.jwt.JwtValidationType.VALID_JWT;
+import static org.sopt.jaksim.global.common.Constants.AUTHORIZATION;
+import static org.sopt.jaksim.global.common.Constants.BEARER;
 
 @Component
 @RequiredArgsConstructor
@@ -33,8 +35,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         try {
             final String token = getJwtFromRequest(request);
             if (jwtTokenProvider.validateToken(token) == VALID_JWT) {
-                Long memberId = jwtTokenProvider.getUserFromJwt(token);
-                UserAuthentication authentication = UserAuthentication.createUserAuthentication(memberId);
+                Long userId = jwtTokenProvider.getUserFromJwt(token);
+                UserAuthentication authentication = UserAuthentication.createUserAuthentication(userId);
                 authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
@@ -45,9 +47,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private String getJwtFromRequest(HttpServletRequest request) {
-        String bearerToken = request.getHeader("Authorization");
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
-            return bearerToken.substring("Bearer ".length());
+        String bearerToken = request.getHeader(AUTHORIZATION);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER)) {
+            return bearerToken.substring(BEARER.length());
         }
         return null;
     }

--- a/jaksim/src/main/java/org/sopt/jaksim/auth/jwt/JwtTokenProvider.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/auth/jwt/JwtTokenProvider.java
@@ -1,4 +1,4 @@
-package org.sopt.jaksim.global.common.jwt;
+package org.sopt.jaksim.auth.jwt;
 
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;

--- a/jaksim/src/main/java/org/sopt/jaksim/auth/jwt/JwtTokenProvider.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/auth/jwt/JwtTokenProvider.java
@@ -3,6 +3,8 @@ package org.sopt.jaksim.auth.jwt;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
+import org.sopt.jaksim.global.exception.UnauthorizedException;
+import org.sopt.jaksim.global.message.ErrorMessage;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
@@ -64,6 +66,12 @@ public class JwtTokenProvider {
             return JwtValidationType.UNSUPPORTED_JWT_TOKEN;
         } catch (IllegalArgumentException ex) {
             return JwtValidationType.EMPTY_JWT;
+        }
+    }
+
+    public void equalsRefreshToken(String refreshToken, String storedRefreshToken) {
+        if(!refreshToken.equals(storedRefreshToken)) {
+            throw new UnauthorizedException(ErrorMessage.MISMATCH_REFRESH_TOKEN);
         }
     }
 

--- a/jaksim/src/main/java/org/sopt/jaksim/auth/jwt/JwtValidationType.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/auth/jwt/JwtValidationType.java
@@ -1,4 +1,4 @@
-package org.sopt.jaksim.global.common.jwt;
+package org.sopt.jaksim.auth.jwt;
 
 public enum JwtValidationType {
     VALID_JWT,              // 유효한 JWT

--- a/jaksim/src/main/java/org/sopt/jaksim/global/common/Constants.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/global/common/Constants.java
@@ -2,5 +2,10 @@ package org.sopt.jaksim.global.common;
 
 public abstract class Constants {
     public static final String AUTHORIZATION = "Authorization";
+    public static final String BEARER = "Bearer ";
+    public static final String ACTIVATE_PROFILE_URL = "/profile";
+    public static final String WEB_SOCKET_SERVER_URL = "/ws/**";
+
+
 
 }

--- a/jaksim/src/main/java/org/sopt/jaksim/global/common/HealthCheckController.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/global/common/HealthCheckController.java
@@ -2,6 +2,8 @@ package org.sopt.jaksim.global.common;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.sopt.jaksim.auth.UserAuthentication;
+import org.sopt.jaksim.auth.jwt.JwtTokenProvider;
 import org.springframework.core.env.Environment;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;

--- a/jaksim/src/main/java/org/sopt/jaksim/global/exception/GlobalExceptionHandler.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/global/exception/GlobalExceptionHandler.java
@@ -45,4 +45,10 @@ public class GlobalExceptionHandler {
         log.error(">>> handle: IOException ", e);
         return ApiResponseUtil.failure(ErrorMessage.BAD_REQUEST);
     }
+
+    @ExceptionHandler(OAuthException.class)
+    protected ResponseEntity<BaseResponse<?>> handlerOAuthException(OAuthException e) {
+        log.error(">>> handle: OAuthException ", e);
+        return ApiResponseUtil.failure(ErrorMessage.INVALID_GRANT_BY_OAUTH);
+    }
 }

--- a/jaksim/src/main/java/org/sopt/jaksim/global/exception/GlobalExceptionHandler.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,8 @@
-package org.sopt.jaksim.global.common;
+package org.sopt.jaksim.global.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.sopt.jaksim.global.common.ApiResponseUtil;
+import org.sopt.jaksim.global.common.BaseResponse;
 import org.sopt.jaksim.global.exception.ForbiddenException;
 import org.sopt.jaksim.global.exception.NotFoundException;
 import org.sopt.jaksim.global.exception.UnauthorizedException;
@@ -36,5 +38,11 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<BaseResponse<?>> handlerUnauthorizedException(UnauthorizedException e) {
         log.error(">>> handle: UnauthorizedException ", e);
         return ApiResponseUtil.failure(ErrorMessage.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(IOException.class)
+    protected ResponseEntity<BaseResponse<?>> handlerIOException(IOException e) {
+        log.error(">>> handle: IOException ", e);
+        return ApiResponseUtil.failure(ErrorMessage.BAD_REQUEST);
     }
 }

--- a/jaksim/src/main/java/org/sopt/jaksim/global/exception/IOException.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/global/exception/IOException.java
@@ -1,0 +1,9 @@
+package org.sopt.jaksim.global.exception;
+
+import org.sopt.jaksim.global.message.ErrorMessage;
+
+public class IOException extends BusinessException {
+    public IOException(ErrorMessage errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/jaksim/src/main/java/org/sopt/jaksim/global/exception/OAuthException.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/global/exception/OAuthException.java
@@ -1,0 +1,9 @@
+package org.sopt.jaksim.global.exception;
+
+import org.sopt.jaksim.global.message.ErrorMessage;
+
+public class OAuthException extends BusinessException {
+    public OAuthException(ErrorMessage errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/jaksim/src/main/java/org/sopt/jaksim/global/message/ErrorMessage.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/global/message/ErrorMessage.java
@@ -13,13 +13,15 @@ public enum ErrorMessage {
      */
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "e4000", "잘못된 요청입니다."),
     INVALID_PLATFORM_TYPE(HttpStatus.BAD_REQUEST, "e4001", "유효하지 않은 플랫폼 타입입니다."),
-
+    INVALID_GRANT_BY_OAUTH(HttpStatus.BAD_REQUEST, "e4002", "유효하지 않은 인가 코드입니다. 이미 회원가입된 사용자입니다."),
     /**
      * 401 Unauthorized
      */
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "e4010", "리소스 접근 권한이 없습니다."),
     JWT_UNAUTHORIZED_EXCEPTION(HttpStatus.UNAUTHORIZED, "e4011", "사용자의 로그인 검증을 실패했습니다."),
-    PASSWORD_NOT_MATCHED_EXCEPTION(HttpStatus.UNAUTHORIZED, "e4012", "해당 유저의 비밀번호가 일치하지 않습니다."),
+    INVALID_ID_TOKEN(HttpStatus.UNAUTHORIZED, "e4013", "해당 유저의 ID 토큰이 유효하지 않습니다."),
+    INVALID_ID_TOKEN_IS_NULL(HttpStatus.UNAUTHORIZED, "e4014", "해당 유저의 ID 토큰이 null 입니다."),
+    MISMATCH_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "e4015", "리프레시 토큰이 일치하지 않습니다."),
 
     /**
      * 403 Forbidden
@@ -30,6 +32,7 @@ public enum ErrorMessage {
      * 404 Not Found
      */
     NOT_FOUND(HttpStatus.NOT_FOUND, "e4040", "대상을 찾을 수 없습니다."),
+    NOT_FOUND_REFRESH_TOKEN_FROM_REDIS(HttpStatus.NOT_FOUND, "e4041", "리프레시 토큰을 찾을 수 없습니다."),
 
     /**
      * 405 Method Not Allowed

--- a/jaksim/src/main/java/org/sopt/jaksim/socket/WebSocketConfig.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/socket/WebSocketConfig.java
@@ -1,0 +1,21 @@
+package org.sopt.jaksim.socket;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+@Configuration
+@EnableWebSocket
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketConfigurer {
+
+    private final WebSocketHandler webSocketHandler;
+
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        registry.addHandler(webSocketHandler, "/test").setAllowedOrigins("*");
+    }
+}

--- a/jaksim/src/main/java/org/sopt/jaksim/socket/WebSocketHandler.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/socket/WebSocketHandler.java
@@ -1,0 +1,49 @@
+package org.sopt.jaksim.socket;
+
+import org.sopt.jaksim.global.exception.IOException;
+import org.sopt.jaksim.global.message.ErrorMessage;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.io.IOException.*;
+
+@Component
+public class WebSocketHandler extends TextWebSocketHandler {
+
+    // Web Session을 담아두기 위한 맵 형식의 공간
+    private static final ConcurrentHashMap<String, WebSocketSession> CLIENTS = new ConcurrentHashMap<>();
+
+    // 사용자가 웹 소켓 서버에 접속하면 동작
+    // 세션의 고유값을 key, WebSocketSession 값을 value로 CLIENT 변수에 저장
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+        CLIENTS.put(session.getId(), session);
+    }
+
+    // 웹 소켓 서버 접속이 끝났을 때 동작
+    // CLIENT 변수에 있는 해당 세션을 제거
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
+        CLIENTS.remove(session.getId());
+    }
+
+    // 사용자의 메시지를 받게 되면 동작
+    // CLIENT 변수에 담긴 세션 값들을 가져와서 반복문으로 돌려서 메세지를 발송하면, 본인 이외의 사용자에게 메시지를 보냄
+    @Override
+    protected void handleTextMessage(WebSocketSession session, TextMessage message) {
+        String id = session.getId();  //메시지를 보낸 아이디
+        CLIENTS.entrySet().forEach( arg->{
+            if(!arg.getKey().equals(id)) {  //같은 아이디가 아니면 메시지를 전달합니다.
+                try {
+                    arg.getValue().sendMessage(message);
+                } catch (java.io.IOException e) {
+                    throw new IOException(ErrorMessage.BAD_REQUEST);
+                }
+            }
+        });
+    }
+}

--- a/jaksim/src/main/java/org/sopt/jaksim/user/api/SocialLoginTempController.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/user/api/SocialLoginTempController.java
@@ -1,0 +1,26 @@
+package org.sopt.jaksim.user.api;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/login")
+public class SocialLoginTempController {
+
+    // https://accounts.google.com/o/oauth2/v2/auth?scope=email%20profile&access_type=offline&include_granted_scopes=true&response_type=code&state=state_parameter_passthrough_value&redirect_uri=http://localhost:8080/login/oauth2/code/google&client_id=659770443420-vbmil1na1ls85peb64g8krccn7ulmvu2.apps.googleusercontent.com
+    // Goolge이 Redirect로 보내는 URL, Authorization code 반환
+    // 클라에서 해줄 작업
+    @GetMapping("/oauth2/code/google")
+    public void redirectByGoogle(@RequestParam("code") String code) throws GeneralSecurityException, IOException {
+        log.info("authorization code : " + code);
+    }
+}

--- a/jaksim/src/main/java/org/sopt/jaksim/user/api/UserApi.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/user/api/UserApi.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.sopt.jaksim.global.common.BaseResponse;
 import org.sopt.jaksim.user.dto.request.UserSignInRequest;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 
@@ -19,7 +20,7 @@ public interface UserApi {
             responses = {
                     @ApiResponse(
                             responseCode = "200",
-                            description = "요청이 성공했습니다."),
+                            description = "로그인이 완료되었습니다."),
                     @ApiResponse(
                             responseCode = "400",
                             description = "잘못된 요청입니다.",
@@ -29,16 +30,20 @@ public interface UserApi {
                             description = "유효하지 않은 플랫폼 타입입니다.",
                             content = @Content),
                     @ApiResponse(
-                            responseCode = "401",
-                            description = "애플 아이덴티티 토큰의 형식이 올바르지 않습니다.",
+                            responseCode = "400",
+                            description = "유효하지 않은 인가 코드입니다. 이미 회원가입된 사용자입니다.",
                             content = @Content),
                     @ApiResponse(
                             responseCode = "401",
-                            description = "구글 Authorization Code 값이 올바르지 않습니다.",
+                            description = " 사용자의 로그인 검증을 실패했습니다.",
                             content = @Content),
                     @ApiResponse(
                             responseCode = "401",
-                            description = "구글 ID 토큰 값이 올바르지 않습니다.",
+                            description = "해당 유저의 ID 토큰이 유효하지 않습니다.",
+                            content = @Content),
+                    @ApiResponse(
+                            responseCode = "401",
+                            description = "해당 유저의 ID 토큰이 null 입니다.",
                             content = @Content),
                     @ApiResponse(
                             responseCode = "404",
@@ -52,7 +57,7 @@ public interface UserApi {
                             responseCode = "500",
                             description = "서버 내부 오류입니다.",
                             content = @Content)})
-    ResponseEntity<BaseResponse<?>> signIn(@RequestHeader(AUTHORIZATION) final String token,
-                                           @RequestBody final UserSignInRequest request);
+    @PostMapping("/user/signin")
+    public ResponseEntity<BaseResponse<?>> signin(@RequestHeader(AUTHORIZATION) final String accessToken);
 
 }

--- a/jaksim/src/main/java/org/sopt/jaksim/user/api/UserApiController.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/user/api/UserApiController.java
@@ -1,36 +1,42 @@
 package org.sopt.jaksim.user.api;
 
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import org.sopt.jaksim.auth.PrincipalHandler;
+import lombok.extern.slf4j.Slf4j;
 import org.sopt.jaksim.global.common.ApiResponseUtil;
 import org.sopt.jaksim.global.common.BaseResponse;
 import org.sopt.jaksim.global.message.SuccessMessage;
+import org.sopt.jaksim.user.dto.request.UserSignUpRequest;
 import org.sopt.jaksim.user.dto.request.UserReissueRequest;
 import org.sopt.jaksim.user.dto.request.UserSignInRequest;
 import org.sopt.jaksim.user.dto.response.UserSignInResponse;
+import org.sopt.jaksim.user.dto.response.UserSignUpResponse;
 import org.sopt.jaksim.user.facade.UserFacade;
-import org.sopt.jaksim.user.service.UserService;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import static org.sopt.jaksim.global.common.Constants.AUTHORIZATION;
-import static org.sopt.jaksim.global.message.SuccessMessage.USER_SIGN_IN_SUCCESS;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1")
-public class UserApiController {
+public class UserApiController implements UserApi{
 
     private final UserFacade userFacade;
 
-//    @PostMapping("/user/login")
-//    public ResponseEntity<BaseResponse<UserSignInResponse>> login(@RequestBody UserSignInRequest userSignInRequest) {
-//        final UserSignInResponse response = userFacade.login(userSignInRequest);
-//        return ResponseEntity.status(HttpStatus.OK)
-//                .body(SuccessStatusResponse.of(SuccessMessage.USER_SIGN_IN_SUCCESS, response));
-//    }
+    @PostMapping("/auth/google/callback")
+    public ResponseEntity<BaseResponse<?>> signup(@RequestBody final UserSignUpRequest userSignUpRequest) {
+        UserSignUpResponse response = userFacade.signup(userSignUpRequest);
+        return ApiResponseUtil.success(SuccessMessage.USER_SIGN_UP_SUCCESS, response);
+    }
+
+    @Override
+    @PostMapping("/user/signin")
+    public ResponseEntity<BaseResponse<?>> signin(@RequestHeader(AUTHORIZATION) final String accessToken) {
+        final UserSignInResponse response = userFacade.signin();
+        return ApiResponseUtil.success(SuccessMessage.USER_SIGN_IN_SUCCESS, response);
+    }
 //
 
     @PostMapping("/reissue")

--- a/jaksim/src/main/java/org/sopt/jaksim/user/domain/User.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/user/domain/User.java
@@ -24,4 +24,11 @@ public class User extends BaseTimeEntity {
     private Platform platform;
     private String refreshToken;
 
+    public static User createUser(String email, String name) {
+        return User.builder()
+                .email(email)
+                .name(name)
+                .platform(Platform.GOOGLE)
+                .build();
+    }
 }

--- a/jaksim/src/main/java/org/sopt/jaksim/user/dto/Tokens.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/user/dto/Tokens.java
@@ -1,0 +1,11 @@
+package org.sopt.jaksim.user.dto;
+
+public record Tokens (
+    String accessToken,
+    String refreshToken,
+    String idToken
+) {
+    public static Tokens of(String accessToken, String refreshToken, String idToken) {
+        return new Tokens(accessToken, refreshToken, idToken);
+    }
+}

--- a/jaksim/src/main/java/org/sopt/jaksim/user/dto/UserInfo.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/user/dto/UserInfo.java
@@ -1,0 +1,15 @@
+package org.sopt.jaksim.user.dto;
+
+public record UserInfo(
+        String userId,
+        String email,
+        String name,
+        String pictureUrl,
+        String locale,
+        String familyName,
+        String givenName
+) {
+    public static UserInfo of (String userId, String email, String name, String pictureUrl, String locale, String familyName, String givenName) {
+        return new UserInfo(userId, email, name, pictureUrl, locale, familyName, givenName);
+    }
+}

--- a/jaksim/src/main/java/org/sopt/jaksim/user/dto/request/UserSignUpRequest.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/user/dto/request/UserSignUpRequest.java
@@ -1,0 +1,6 @@
+package org.sopt.jaksim.user.dto.request;
+
+public record UserSignUpRequest(
+        String authorizationCode
+) {
+}

--- a/jaksim/src/main/java/org/sopt/jaksim/user/dto/response/UserSignUpResponse.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/user/dto/response/UserSignUpResponse.java
@@ -1,0 +1,13 @@
+package org.sopt.jaksim.user.dto.response;
+
+import org.sopt.jaksim.user.dto.UserInfo;
+
+public record UserSignUpResponse(
+        String accessToken,
+        String refreshToken,
+        UserInfo userInfo
+) {
+    public static UserSignUpResponse of (String accessToken, String refreshToken, UserInfo userInfo) {
+        return new UserSignUpResponse(accessToken, refreshToken, userInfo);
+    }
+}

--- a/jaksim/src/main/java/org/sopt/jaksim/user/facade/UserFacade.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/user/facade/UserFacade.java
@@ -1,8 +1,13 @@
 package org.sopt.jaksim.user.facade;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.jaksim.user.dto.Tokens;
+import org.sopt.jaksim.user.dto.UserInfo;
+import org.sopt.jaksim.user.dto.request.UserSignUpRequest;
 import org.sopt.jaksim.user.dto.request.UserReissueRequest;
+import org.sopt.jaksim.user.dto.request.UserSignInRequest;
 import org.sopt.jaksim.user.dto.response.UserSignInResponse;
+import org.sopt.jaksim.user.dto.response.UserSignUpResponse;
 import org.sopt.jaksim.user.service.UserService;
 import org.springframework.stereotype.Component;
 
@@ -11,7 +16,18 @@ import org.springframework.stereotype.Component;
 public class UserFacade {
     private final UserService userService;
 
+    public UserSignUpResponse signup(UserSignUpRequest userSignUpRequest) {
+        return userService.signup(userSignUpRequest);
+    }
+
+    public UserSignInResponse signin() {
+        return userService.signIn();
+    }
+
     public UserSignInResponse reissue(String refreshToken, UserReissueRequest userReissueRequest) {
         return userService.reissue(refreshToken, userReissueRequest);
     }
+
+
+
 }

--- a/jaksim/src/main/java/org/sopt/jaksim/user/service/UserService.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/user/service/UserService.java
@@ -2,8 +2,9 @@ package org.sopt.jaksim.user.service;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.jaksim.auth.UserAuthentication;
-import org.sopt.jaksim.global.common.jwt.JwtTokenProvider;
+import org.sopt.jaksim.auth.jwt.JwtTokenProvider;
 import org.sopt.jaksim.global.exception.NotFoundException;
+
 import org.sopt.jaksim.global.message.ErrorMessage;
 import org.sopt.jaksim.user.domain.Platform;
 import org.sopt.jaksim.user.domain.RefreshToken;

--- a/jaksim/src/main/java/org/sopt/jaksim/user/service/UserService.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/user/service/UserService.java
@@ -1,60 +1,193 @@
 package org.sopt.jaksim.user.service;
 
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.jaksim.auth.PrincipalHandler;
 import org.sopt.jaksim.auth.UserAuthentication;
 import org.sopt.jaksim.auth.jwt.JwtTokenProvider;
 import org.sopt.jaksim.global.exception.NotFoundException;
+import org.sopt.jaksim.global.exception.OAuthException;
+import org.sopt.jaksim.global.exception.UnauthorizedException;
 import org.sopt.jaksim.global.message.ErrorMessage;
 import org.sopt.jaksim.user.domain.Platform;
 import org.sopt.jaksim.user.domain.RefreshToken;
+import org.sopt.jaksim.user.dto.Tokens;
 import org.sopt.jaksim.user.domain.User;
+import org.sopt.jaksim.user.dto.UserInfo;
 import org.sopt.jaksim.user.dto.request.UserReissueRequest;
 import org.sopt.jaksim.user.dto.request.UserSignInRequest;
+import org.sopt.jaksim.user.dto.request.UserSignUpRequest;
 import org.sopt.jaksim.user.dto.response.UserSignInResponse;
+import org.sopt.jaksim.user.dto.response.UserSignUpResponse;
 import org.sopt.jaksim.user.repository.RedisTokenRepository;
 import org.sopt.jaksim.user.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.json.JSONObject;
 
-import static org.sopt.jaksim.user.domain.Platform.getEnumPlatformFromStringPlatform;
+import java.util.Collections;
+
+
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
     private final JwtTokenProvider jwtTokenProvider;
+    private final PrincipalHandler principalHandler;
     private final RedisTokenRepository redisTokenRepository;
 
-    @Transactional
-    public UserSignInResponse signIn(String token, UserSignInRequest request) {
-        Platform platform = getEnumPlatformFromStringPlatform(request.platform());
-        // 플랫폼을 판단한 뒤, 토큰을 넣어서 유저 이메일 추출
-        String userEmail = getUserEmail(token, platform);
+    @Value("${spring.security.oauth2.client.registration.google.client-id}") String CLIENT_ID;
+    @Value("${spring.security.oauth2.client.registration.google.client-secret}") String CLIENT_SECRET;
+    @Value("${google.redirect-url}") String REDIRECT_URL;
+    @Value("${google.request-url}") String REQUEST_URL;
 
-        // 유저 이메일과 플랫폼으로 유저 찾기
-        User user = getUserByPlatformAndEmail(platform, userEmail);
+    @Transactional
+    public UserSignUpResponse signup(UserSignUpRequest userSignUpRequest) {
+        try {
+            Tokens tokens = createTokens(userSignUpRequest.authorizationCode());
+            UserInfo userInfo = validateIdToken(tokens.idToken());
+            User saveUser = saveUser(userInfo);
+            String accessToken = issueAccessTokenByUserId(saveUser.getId());
+            String refreshToken = issueRefreshTokenByUserId(saveUser.getId());
+            updateRefreshToken(refreshToken, saveUser);
+            return UserSignUpResponse.of(accessToken, refreshToken, userInfo);
+        } catch (Exception e) {
+            if (e.getMessage().contains("invalid_grant")) {
+                throw new OAuthException(ErrorMessage.INVALID_GRANT_BY_OAUTH);
+            }
+        }
+        return null;
+    }
+
+    @Transactional
+    public UserSignInResponse signIn() {
+        User user = getUserByPrincipal();
 
         // atk, rtk 발급
-        String accessToken = jwtTokenProvider.issueAccessToken(UserAuthentication.createUserAuthentication(user.getId()));
-        String refreshToken = jwtTokenProvider.issueRefreshToken(UserAuthentication.createUserAuthentication(user.getId()));
+        String accessToken = issueAccessTokenByUserId(user.getId());
+        String refreshToken = issueRefreshTokenByUserId(user.getId());
 
         // redis에 rtk 저장
         redisTokenRepository.save(RefreshToken.of(user.getId(), refreshToken));
-
+        updateRefreshToken(refreshToken, user);
         return UserSignInResponse.of(accessToken, refreshToken, user.getId().toString());
+    }
+
+    public Tokens createTokens(String authCode) {
+        HttpEntity<MultiValueMap<String, String>> entity = setHeaderAndParameter(authCode);
+        Tokens tokens = handleTokenRequest(entity);
+        return tokens;
+    }
+
+    public UserInfo validateIdToken(String idToken) {
+        try {
+            GoogleIdTokenVerifier verifier = new GoogleIdTokenVerifier.Builder(getHttpTransport(), getJsonFactory())
+                    .setAudience(Collections.singletonList(CLIENT_ID))
+                    .build();
+
+            GoogleIdToken validatedIdToken = verifier.verify(idToken);
+
+            if (idToken != null) {
+                UserInfo userInfo = parseIdToken(validatedIdToken);
+                return userInfo;
+            } else {
+                throw new UnauthorizedException(ErrorMessage.INVALID_ID_TOKEN_IS_NULL);
+            }
+        }
+        catch (Exception e) {
+            throw new UnauthorizedException(ErrorMessage.INVALID_ID_TOKEN);
+        }
+    }
+
+    public HttpEntity<MultiValueMap<String, String>> setHeaderAndParameter(String authCode) {
+        // Header Setting
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // Parameter Setting
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("code", authCode);
+        params.add("client_id", CLIENT_ID);
+        params.add("client_secret", CLIENT_SECRET);
+        params.add("grant_type", "authorization_code");
+        params.add("redirect_uri", REDIRECT_URL);
+
+        return new HttpEntity<>(params, headers);
+    }
+
+    public Tokens handleTokenRequest(HttpEntity<?> entity) {
+        // RestTemplate Initialize
+        RestTemplate rt = new RestTemplate();
+
+        // 전송 및 결과 처리
+        ResponseEntity<String> response = rt.exchange(
+                REQUEST_URL,
+                HttpMethod.POST,
+                entity,
+                String.class
+        );
+
+        String result = response.getBody();
+        JSONObject jsonObject = new JSONObject(result);
+        String accessToken = jsonObject.getString("access_token");
+        String refreshToken = jsonObject.getString("refresh_token");
+        String idToken = jsonObject.getString("id_token");
+        return Tokens.of(accessToken, refreshToken, idToken);
+    }
+
+    private HttpTransport getHttpTransport() {
+        return new NetHttpTransport();
+    }
+
+    private JsonFactory getJsonFactory() {
+        JsonFactory jsonFactory = new JacksonFactory(); //lo 예시로 JacksonFactory 사용
+        return jsonFactory;
+    }
+
+    private UserInfo parseIdToken (GoogleIdToken validatedIdToken) {
+        GoogleIdToken.Payload payload = validatedIdToken.getPayload();
+
+        return UserInfo.of(
+                payload.getSubject(),
+                payload.getEmail(),
+                (String) payload.get("name"),
+                (String) payload.get("picture"),
+                (String) payload.get("locale"),
+                (String) payload.get("family_name"),
+                (String) payload.get("given_name")
+        );
+    }
+
+    public User saveUser(UserInfo userInfo) {
+        User user = User.createUser(userInfo.email(), userInfo.name());
+        return userRepository.save(user);
     }
 
     public UserSignInResponse reissue(String token, UserReissueRequest userReissueRequest) {
        Long userId = userReissueRequest.userId();
        validateRefreshToken(token, userId);
        User user = getUser(userId);
-
-       String accessToken = jwtTokenProvider.issueAccessToken(UserAuthentication.createUserAuthentication(userId));
-       String refreshToken = jwtTokenProvider.issueRefreshToken(UserAuthentication.createUserAuthentication(userId));
-
+       String accessToken = issueAccessTokenByUserId(userId);
+       String refreshToken = issueRefreshTokenByUserId(userId);
        updateRefreshToken(refreshToken, user);
-
-        return new UserSignInResponse(accessToken, refreshToken, userId.toString());
+       return UserSignInResponse.of(accessToken, refreshToken, userId.toString());
     }
 
     private User getUser(Long userId) {
@@ -63,21 +196,33 @@ public class UserService {
         );
     }
 
-    private User getUserByPlatformAndEmail(Platform platform, String userEmail) {
-        return userRepository.findUserByPlatformAndEmail(platform, userEmail).orElseThrow(
-            () -> new NotFoundException(ErrorMessage.NOT_FOUND));
+    public User getUserByPrincipal() {
+        Long userId = principalHandler.getUserIdFromPrincipal();
+        return userRepository.findById(userId).orElseThrow(
+                () -> new NotFoundException(ErrorMessage.NOT_FOUND)
+        );
     }
 
-    public String getUserEmail(String token, Platform platform) {
-        // 추후에 다른 소셜로그인 플랫폼이 있을 수도 있으므로 메소드로 분리함
-        // 구글 OAuth 서버에 통신해서 이메일 가져오기
-        return null;
+    private String issueAccessTokenByUserId(Long userId) {
+        return jwtTokenProvider.issueAccessToken(UserAuthentication.createUserAuthentication(userId));
+    }
+
+    private String issueRefreshTokenByUserId(Long userId) {
+        return jwtTokenProvider.issueRefreshToken(UserAuthentication.createUserAuthentication(userId));
     }
 
     private void validateRefreshToken(String refreshToken, Long userId) {
         // jwt 클래스 따로 만들어서 할 예정
+        jwtTokenProvider.validateToken(refreshToken);
+        String storedRefreshToken = getRefreshTokenFromRedis(userId).getRefreshToken();
+        jwtTokenProvider.equalsRefreshToken(refreshToken,storedRefreshToken);
     }
 
+    private RefreshToken getRefreshTokenFromRedis(Long userId) {
+        return redisTokenRepository.findById(userId).orElseThrow(
+                () -> new NotFoundException(ErrorMessage.NOT_FOUND_REFRESH_TOKEN_FROM_REDIS)
+        );
+    }
     private void updateRefreshToken(String refreshToken, User user) {
         user.setRefreshToken(refreshToken);
         redisTokenRepository.save(RefreshToken.of(user.getId(), refreshToken));

--- a/jaksim/src/main/java/org/sopt/jaksim/user/service/UserService.java
+++ b/jaksim/src/main/java/org/sopt/jaksim/user/service/UserService.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.jaksim.auth.UserAuthentication;
 import org.sopt.jaksim.auth.jwt.JwtTokenProvider;
 import org.sopt.jaksim.global.exception.NotFoundException;
-
 import org.sopt.jaksim.global.message.ErrorMessage;
 import org.sopt.jaksim.user.domain.Platform;
 import org.sopt.jaksim.user.domain.RefreshToken;


### PR DESCRIPTION
## 🍀 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
## 구글을 이용한 회원가입 API
### 클라이언트 작업을 대신해 줄 Test API - SocialLoginTempController
https://github.com/jaksim-us/Jaksim-Server/blob/dc434137faf8790b3506c25b0667c219bc2d69dd/jaksim/src/main/java/org/sopt/jaksim/user/api/SocialLoginTempController.java#L16-L26
- 소셜 로그인 창에서 로그인 하면 인가 코드를 구글에서 발급해주는데, 이 코드를 클라이언트에서 구글 서버에 요청해서 받아오는 API를 테스트하기 위해 만들었습니다.
- 나중에는, 클라이언트가 보내줄 정보입니다 :)

### controller
https://github.com/jaksim-us/Jaksim-Server/blob/dc434137faf8790b3506c25b0667c219bc2d69dd/jaksim/src/main/java/org/sopt/jaksim/user/api/UserApiController.java#L28-L32
- UserSignUpRequest (인가 코드를 포함한) 를 파라미터로 받아서 userFacade로 던짐

### facade
https://github.com/jaksim-us/Jaksim-Server/blob/dc434137faf8790b3506c25b0667c219bc2d69dd/jaksim/src/main/java/org/sopt/jaksim/user/api/UserApiController.java#L28-L32
- facade는 service로 dto를 던짐

### service
https://github.com/jaksim-us/Jaksim-Server/blob/dc434137faf8790b3506c25b0667c219bc2d69dd/jaksim/src/main/java/org/sopt/jaksim/user/service/UserService.java#L56-L59
- application.yaml의 비밀 정보들을 `@Value`로 받음 

https://github.com/jaksim-us/Jaksim-Server/blob/dc434137faf8790b3506c25b0667c219bc2d69dd/jaksim/src/main/java/org/sopt/jaksim/user/service/UserService.java#L61-L77
- service의 회원가입 로직입니다. 순차적으로 설명해볼게요 :)

### service - 토큰 발급

`createTokens`
https://github.com/jaksim-us/Jaksim-Server/blob/dc434137faf8790b3506c25b0667c219bc2d69dd/jaksim/src/main/java/org/sopt/jaksim/user/service/UserService.java#L93-L97

`setHeaderAndParameter`
https://github.com/jaksim-us/Jaksim-Server/blob/dc434137faf8790b3506c25b0667c219bc2d69dd/jaksim/src/main/java/org/sopt/jaksim/user/service/UserService.java#L119-L133

`handleTokenRequest`
https://github.com/jaksim-us/Jaksim-Server/blob/dc434137faf8790b3506c25b0667c219bc2d69dd/jaksim/src/main/java/org/sopt/jaksim/user/service/UserService.java#L135-L153

- `createTokens`는 RestTemplate를 이용해 구글 OAuth 서버에 전달받은 인가코드를 보내 atk, rtk, itk를 발급받는 메소드입니다.
- 그 안의 `setHeaderAndParameter`는 RestTemplate 요청 시 포함되어야 할 헤더와 파라미터를 세팅하는 메소드입니다. client_id, client_secret, 인가 코드, redirect_url이 포함됩니다.
- `handleTokenRequest`는 RestTemplate 객체를 만들어 HttpEntity를 전달받아 실제로 요청을 보내고, 응답받은 토큰들을 Tokens 레코드에 저장해 반환합니다.

### service - itk 검증 후 validation & parsing
`validateIdToken`
https://github.com/jaksim-us/Jaksim-Server/blob/dc434137faf8790b3506c25b0667c219bc2d69dd/jaksim/src/main/java/org/sopt/jaksim/user/service/UserService.java#L99-L117

`parseIdToken`
https://github.com/jaksim-us/Jaksim-Server/blob/dc434137faf8790b3506c25b0667c219bc2d69dd/jaksim/src/main/java/org/sopt/jaksim/user/service/UserService.java#L164-L176

- GoogleIdTokenVerifier를 이용해 아까 발급받았던 토큰 중 idToken을 검증합니다. 클라이언트가 1개이기 때문에 (스프링부트 서버) CLIENT_ID를 SingleTonList로 Audience에 등록했습니다.
- 이 itk에는 유저의 정보가 담겨있기 때문에 `parseIdToken`를 이용해 UserInfo 레코드에 정보를 추가하고 반환합니다.

### service - 저장

`saveUser`
https://github.com/jaksim-us/Jaksim-Server/blob/dc434137faf8790b3506c25b0667c219bc2d69dd/jaksim/src/main/java/org/sopt/jaksim/user/service/UserService.java#L178-L181

 `issueAccessToken & issueRefreshToken`
https://github.com/jaksim-us/Jaksim-Server/blob/dc434137faf8790b3506c25b0667c219bc2d69dd/jaksim/src/main/java/org/sopt/jaksim/user/service/UserService.java#L206-L212

`updateRefreshToken`
https://github.com/jaksim-us/Jaksim-Server/blob/dc434137faf8790b3506c25b0667c219bc2d69dd/jaksim/src/main/java/org/sopt/jaksim/user/service/UserService.java#L226-L229

- `saveUser`로 DB에 유저를 저장합니다.
- `issue..Token` 메소드로 atk, rtk를 발급합니다.
- `updateRefreshToken` 는 유저 DB의 refreshToken과 Redis의 refreshToken 값을 업데이트합니다.

## 로그인 API
### controller
https://github.com/jaksim-us/Jaksim-Server/blob/dc434137faf8790b3506c25b0667c219bc2d69dd/jaksim/src/main/java/org/sopt/jaksim/user/api/UserApiController.java#L34-L39
- Authorization 필드에 들어있는 atk를 `@RequestHeader`로 추출합니다.
- 회원가입과 마찬가지로, userFacade로 넘깁니다.
- 여기는 dto가 없습니다. 이유는, 소셜 로그인이기 때문에 atk 만이 인증 방식이고, 아이디나 비밀번호 같은 추가 정보를 받을 필요가 없기 때문입니다 :)

### service
https://github.com/jaksim-us/Jaksim-Server/blob/dc434137faf8790b3506c25b0667c219bc2d69dd/jaksim/src/main/java/org/sopt/jaksim/user/service/UserService.java#L79-L91

### service - getUserByPrincipal
https://github.com/jaksim-us/Jaksim-Server/blob/dc434137faf8790b3506c25b0667c219bc2d69dd/jaksim/src/main/java/org/sopt/jaksim/user/service/UserService.java#L199-L204

- atk를 이용해 로그인을 했으니 SecurityContextHolder에 저장되어 있는 Authentication 객체의 Principal을 꺼내서 userId를 추출합니다. 
- 이 userId로 유저를 검색해서 유저 객체를 반환합니다.

atk, rtk 발급이나 rtk 재발급 로직은 회원가입 API와 동일하니 다시 쓰진 않겠습니다 :)!

<br>

## 🍀 어떤 것을 중점으로 리뷰 해주길 바라시나요?
- OAuth를 이용한 소셜 로그인, 회원가입 전체적인 로직

<br>

## 🍀 공통 작업 부분에 대한 수정 사항이 있다면 적어주세요
- 

<br>

## 🍀 PR 유형
어떤 변경 사항인가요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 파일 혹은 패키지명 수정
- [ ] 파일 혹은 패키지 삭제

<br>

## 🍀 Checklist
- [x] 코드 컨벤션을 지켰나요?
- [x] git 컨벤션을 지켰나요?
- [x] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


### 🍀 Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #16
